### PR TITLE
fix

### DIFF
--- a/03.bff+backend/README.md
+++ b/03.bff+backend/README.md
@@ -37,7 +37,7 @@ cd 03.bff+backend/backend
 ```sh
 # リポジトリルートから
 cd 03.bff+backend/bff
-pnpm dev
+pnpm start:dev
 ```
 
 ## バックエンド


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
    - Updated backend setup instructions in the README to use `pnpm start:dev` instead of `pnpm dev`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->